### PR TITLE
fix for fsspec 2024.5.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,15 +21,15 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Python 3.10
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.12'
+          cache: 'pip'
 
-      - name: Upgrade pip and nox
+      - name: Upgrade nox
         run: |
-          pip install --upgrade pip nox
-          pip --version
+          python -m pip install --upgrade 'nox[uv]'
           nox --version
 
       - name: Build package

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, windows-latest, macos-latest]
-        pyv: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        pyv: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
         include:
           - {os: ubuntu-latest, pyv: 'pypy3.8'}
 
@@ -35,18 +35,19 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.pyv }}
+          allow-prereleases: true
+          cache: 'pip'
 
-      - name: Upgrade pip and nox
+      - name: Upgrade nox
         run: |
-          python -m pip install --upgrade pip nox
-          pip --version
+          python -m pip install --upgrade 'nox[uv]'
           nox --version
 
-      - name: Lint code and check dependencies
-        run: nox -s lint safety
+      - name: Lint code
+        run: nox -s lint
 
       - name: Run tests
-        run: nox -s tests-${{ matrix.nox_pyv || matrix.pyv }} -- --cov-report=xml
+        run: nox -s tests-${{ matrix.pyv }} -- --cov-report=xml
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v3

--- a/noxfile.py
+++ b/noxfile.py
@@ -5,13 +5,24 @@ import os
 
 import nox
 
+nox.options.default_venv_backend = "uv|virtualenv"
 nox.options.reuse_existing_virtualenvs = True
 nox.options.sessions = "lint", "tests"
 locations = "src", "tests"
 
 
 @nox.session(
-    python=["3.8", "3.9", "3.10", "3.11", "3.12", "pypy3.8", "pypy3.9", "pypy3.10"]
+    python=[
+        "3.8",
+        "3.9",
+        "3.10",
+        "3.11",
+        "3.12",
+        "3.13",
+        "pypy3.8",
+        "pypy3.9",
+        "pypy3.10",
+    ]
 )
 def tests(session: nox.Session) -> None:
     session.install(".[tests]")
@@ -35,17 +46,9 @@ def lint(session: nox.Session) -> None:
 
 
 @nox.session
-def safety(session: nox.Session) -> None:
-    """Scan dependencies for insecure packages."""
-    session.install(".[dev]")
-    session.install("safety")
-    session.run("safety", "check", "--full-report")
-
-
-@nox.session
 def build(session: nox.Session) -> None:
-    session.install("build", "setuptools", "twine")
-    session.run("python", "-m", "build")
+    session.install("build", "twine", "uv")
+    session.run("python", "-m", "build", "--installer", "uv")
     dists = glob.glob("dist/*")
     session.run("twine", "check", *dists, silent=True)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Development Status :: 4 - Beta"
 ]
 requires-python = ">=3.8"

--- a/src/morefs/asyn_local.py
+++ b/src/morefs/asyn_local.py
@@ -63,7 +63,11 @@ class AsyncLocalFileSystem(AsyncFileSystem, LocalFileSystem):
     _makedirs = wrap(LocalFileSystem.makedirs)
     _mkdir = wrap(LocalFileSystem.mkdir)
     _modified = wrap(LocalFileSystem.modified)
-    _mv_file = wrap(LocalFileSystem.mv_file)
+
+    # `mv_file` was renamed to `mv` in fsspec==2024.5.0
+    # https://github.com/fsspec/filesystem_spec/pull/1585
+    _mv = wrap(getattr(LocalFileSystem, "mv", None) or LocalFileSystem.mv_file)  # type: ignore[call-overload]
+    _mv_file = _mv
     _pipe_file = wrap(LocalFileSystem.pipe_file)
     _put_file = wrap(LocalFileSystem.put_file)
     _read_bytes = wrap(LocalFileSystem.read_bytes)


### PR DESCRIPTION
`fsspec==2024.5.0` replaced `mv_file` with `mv` in fsspec/filesystem_spec#1585. This commit adds compat for all supported fsspec versions, including the latest.

- Also enable support for Python 3.13,
- Uses uv.
- Remove `safety`.